### PR TITLE
Dev

### DIFF
--- a/mix/ui/psd_model_maya.py
+++ b/mix/ui/psd_model_maya.py
@@ -368,30 +368,21 @@ def add_driven(interp_graph):
             # get all of the driven nodes. Currently only doing blendShapes.
             # TODO: this is currently only blendshapes. We will need to update this to act differently in the future.
             driven_list = rig_psd.getDrivenNodes(interp) or list()
-            geo_list = list()
-            for node in driven_list:
-                if mc.nodeType(node) == 'blendShape':
-                    geo_list = list(set(geo_list + mc.blendShape(node, q=True, g=True)))
-
-            # get the transforms for the shape nodes.
-            geo_list = [mc.listRelatives(geo, p=True)[0] for geo in geo_list]
-            geo_list.extend(sel_list)
 
             # if node in add_list has a blendShape with the same name as geometry, we will use that. Otherwise, we will make
             # a blendShape that is front of chain using the name of geometry as a prefix
-            new_driven_list = list()
-            for geo in geo_list:
+            for geo in sel_list:
                 # get the blendShapes on the geometry
                 geo_blendshape_list = rig_blendShape.getBlendShapes(geo)
                 blendshape_name = '{}_blendShape'.format(geo)
-                if not blendshape_name in geo_blendshape_list:
+                if not geo_blendshape_list:
                     mc.select(geo, r=True)
                     mc.blendShape(name=blendshape_name, frontOfChain=True)
 
-                new_driven_list.append(blendshape_name)
+                driven_list.append(blendshape_name)
 
-            rig_psd.addDriven(interp, new_driven_list)
-            interp_node.getAttributeByName('drivens').setValue(new_driven_list)
+            rig_psd.addDriven(interp, driven_list)
+            interp_node.getAttributeByName('drivens').setValue(driven_list)
             mc.select(sel_list)
     except:
         traceback.print_exc()

--- a/mix/ui/psd_model_maya.py
+++ b/mix/ui/psd_model_maya.py
@@ -367,11 +367,14 @@ def add_driven(interp_graph):
             interp = interp_node.getAttributeByName('full_name').getValue()
             # get all of the driven nodes. Currently only doing blendShapes.
             # TODO: this is currently only blendshapes. We will need to update this to act differently in the future.
-            driven_list = rig_psd.getDrivenNodes(interp) or list()
+            driven_list = list()
 
             # if node in add_list has a blendShape with the same name as geometry, we will use that. Otherwise, we will make
             # a blendShape that is front of chain using the name of geometry as a prefix
             for geo in sel_list:
+                shape_list = mc.listRelatives(geo, c=True, shapes=True, type='mesh')
+                if not shape_list:
+                    continue
                 # get the blendShapes on the geometry
                 geo_blendshape_list = rig_blendShape.getBlendShapes(geo)
                 if not geo_blendshape_list:
@@ -379,16 +382,19 @@ def add_driven(interp_graph):
                     mc.select(geo, r=True)
                     mc.blendShape(name=blendshape_name, frontOfChain=True)
                 elif len(geo_blendshape_list) > 1:
-                    blendshape_name, ok = g_dialog.get_item(title='Select Blendshapes', description='BlendShape',
+                    blendshape_name, ok = g_dialog.get_item(title='Select {} Blendshapes'.format(geo), description='BlendShape',
                                                         default_items=geo_blendshape_list)
+                    print ok
+                    if not ok:
+                        continue
                 else:
                     blendshape_name = geo_blendshape_list[0]
 
                 driven_list.append(blendshape_name)
-
-            rig_psd.addDriven(interp, driven_list)
-            interp_node.getAttributeByName('drivens').setValue(driven_list)
-            mc.select(sel_list)
+            if driven_list:
+                rig_psd.addDriven(interp, driven_list)
+                interp_node.getAttributeByName('drivens').setValue(driven_list)
+        mc.select(sel_list)
     except:
         traceback.print_exc()
     mc.undoInfo(closeChunk=1)

--- a/mix/ui/psd_model_maya.py
+++ b/mix/ui/psd_model_maya.py
@@ -374,10 +374,15 @@ def add_driven(interp_graph):
             for geo in sel_list:
                 # get the blendShapes on the geometry
                 geo_blendshape_list = rig_blendShape.getBlendShapes(geo)
-                blendshape_name = '{}_blendShape'.format(geo)
                 if not geo_blendshape_list:
+                    blendshape_name = '{}_blendShape'.format(geo)
                     mc.select(geo, r=True)
                     mc.blendShape(name=blendshape_name, frontOfChain=True)
+                elif len(geo_blendshape_list) > 1:
+                    blendshape_name, ok = g_dialog.get_item(title='Select Blendshapes', description='BlendShape',
+                                                        default_items=geo_blendshape_list)
+                else:
+                    blendshape_name = geo_blendshape_list[0]
 
                 driven_list.append(blendshape_name)
 

--- a/mix/version.json
+++ b/mix/version.json
@@ -2,6 +2,6 @@
   "MIX": {
     "MAJOR": 0,
     "MINOR": 57,
-    "PATCH": 2
+    "PATCH": 3
   }
 }

--- a/mix/version.json
+++ b/mix/version.json
@@ -2,6 +2,6 @@
   "MIX": {
     "MAJOR": 0,
     "MINOR": 57,
-    "PATCH": 4
+    "PATCH": 5
   }
 }

--- a/mix/version.json
+++ b/mix/version.json
@@ -2,6 +2,6 @@
   "MIX": {
     "MAJOR": 0,
     "MINOR": 57,
-    "PATCH": 3
+    "PATCH": 4
   }
 }


### PR DESCRIPTION
# Changes
`*` Bug Fix, Adding a driven to a node that already had a blendshape was creating a new blendshape with new targets. Instead, we're now only finding "a blendshape" which exists and using that one. In the future, we will allow a dropdown to pick from existing blendshapes.